### PR TITLE
Corrigido bug que não permitia utilizadores marcados com "god" ativar / desativar organizações 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>galaxy</artifactId>
     <packaging>ejb</packaging>
-    <version>2.5.56</version>
+    <version>2.5.56-SNAPSHOT</version>
 
     <name>Universe Galaxy</name>
 

--- a/src/main/java/eu/lpinto/universe/controllers/OrganizationController.java
+++ b/src/main/java/eu/lpinto/universe/controllers/OrganizationController.java
@@ -118,6 +118,17 @@ public class OrganizationController extends AbstractControllerCRUD<Organization>
     }
 
     @Override
+    public void update(Long userID, Map<String, Object> options, Organization entity) throws UnknownIdException, PreConditionException, PermissionDeniedException {
+        User savedUser = userFacade.retrieve(userID);
+
+        if(savedUser.getGod()) {
+            options.put("god", true);
+        }
+
+        super.update(userID, options, entity);
+    }
+
+    @Override
     public void doUpdate(final Long userID, final Map<String, Object> options, Organization newOrganization) {
 
         try {


### PR DESCRIPTION
**PEDIDO DA SUSANA**

- O código dava bypass à verificação de god do utilizador a ativar ou desativar as organizações 

![image](https://github.com/user-attachments/assets/e42c9a94-920c-4fe4-b0c6-63bd6168eb78)
